### PR TITLE
Add flexibility in querying orders, trades and positions #173

### DIFF
--- a/bfxapi/rest/bfx_rest.py
+++ b/bfxapi/rest/bfx_rest.py
@@ -14,6 +14,10 @@ from ..models import Wallet, Order, Position, Trade, FundingLoan, FundingOffer, 
 from ..models import FundingCredit, Notification, Ledger
 
 
+BEGINNING_OF_TIME = 631180800000    # 1990-01-01
+END_OF_TIME = 4102473600000    # 2100-01-01
+
+
 class BfxRest:
     """
     BFX rest interface contains functions which are used to interact with both the public
@@ -401,7 +405,7 @@ class BfxRest:
         else:
             return MarginInfo.from_raw_margin_info(raw_margin_info)
 
-    async def get_active_orders(self, symbol):
+    async def get_active_orders(self, symbol=None):
         """
         Get all of the active orders associated with API_KEY - Requires authentication.
 
@@ -409,11 +413,14 @@ class BfxRest:
         @param symbol string: pair symbol i.e tBTCUSD
         @return Array <models.Order>
         """
-        endpoint = "auth/r/orders/{}".format(symbol)
+        if symbol is None:
+            endpoint = "auth/r/orders"
+        else:
+            endpoint = "auth/r/orders/{}".format(symbol)
         raw_orders = await self.post(endpoint)
         return [Order.from_raw_order(ro) for ro in raw_orders]
 
-    async def get_order_history(self, symbol, start, end, limit=25, sort=-1, ids=None):
+    async def get_order_history(self, symbol=None, start=BEGINNING_OF_TIME, end=END_OF_TIME, limit=2500, sort=-1, ids=None):
         """
         Get all of the orders between the start and end period associated with API_KEY
         - Requires authentication.
@@ -426,7 +433,11 @@ class BfxRest:
         @param ids list of int: allows you to retrieve specific orders by order ID (ids: [ID1, ID2, ID3])
         @return Array <models.Order>
         """
-        endpoint = "auth/r/orders/{}/hist".format(symbol)
+        if symbol is None:
+            endpoint = "auth/r/orders/hist"
+        else:
+            endpoint = "auth/r/orders/{}/hist".format(symbol)
+            
         params = "?start={}&end={}&limit={}&sort={}".format(
             start, end, limit, sort)
         if ids:
@@ -458,7 +469,7 @@ class BfxRest:
         raw_trades = await self.post(endpoint)
         return [Trade.from_raw_rest_trade(rt) for rt in raw_trades]
 
-    async def get_trades(self, symbol, start, end, limit=25):
+    async def get_trades(self, symbol=None, start=BEGINNING_OF_TIME, end=END_OF_TIME, limit=25):
         """
         Get all of the trades between the start and end period associated with API_KEY
         - Requires authentication.
@@ -470,7 +481,11 @@ class BfxRest:
         @param limit int: max number of items in response
         @return Array <models.Trade>
         """
-        endpoint = "auth/r/trades/{}/hist".format(symbol)
+        if symbol is None:
+            endpoint = "auth/r/trades/hist"
+        else:
+            endpoint = "auth/r/trades/{}/hist".format(symbol)
+        
         params = "?start={}&end={}&limit={}".format(start, end, limit)
         raw_trades = await self.post(endpoint, params=params)
         return [Trade.from_raw_rest_trade(rt) for rt in raw_trades]

--- a/bfxapi/tests/test_rest.py
+++ b/bfxapi/tests/test_rest.py
@@ -1,0 +1,184 @@
+"""Tests for REST API
+"""
+import logging
+from datetime import datetime
+from bfxapi.rest.bfx_rest import BfxRest
+import asyncio
+
+# Set auth params
+API_KEY = 'api-key'
+API_SECRET = 'api-secret'
+
+# v2 REST api
+bfx = BfxRest(API_KEY, API_SECRET, loop=None, logLevel='DEBUG', parse_float=float)
+
+
+def test_get_candles():
+    start = 1000 * datetime(2021, 11, 5).timestamp()
+    end = 1000 * datetime(2021, 11, 5, 23).timestamp()
+    
+    # bfxapi returns coroutine objects, which needs to handled later
+    candles = bfx.get_public_candles(
+        'tBTCUSD',
+        start,
+        end,
+        section='hist',
+        tf='1m',
+        limit='100',
+        sort=-1
+    )
+
+    print("\nCandles:")
+    print(asyncio.run(candles))
+
+
+def test_get_active_positions():
+    active_positions = bfx.get_active_position()
+
+    print("\nActive positions:")
+    print(asyncio.run(active_positions))
+
+
+def test_submit_order():
+    symbol = 'tTESTBTC:TESTUSD'
+    price = 25000
+    amount = 0.1
+        
+    submit_order = bfx.submit_order(
+        symbol,
+        price,
+        amount,
+        market_type='EXCHANGE LIMIT',
+        hidden=False,
+        price_trailing=None,
+        price_aux_limit=None,
+        oco_stop_price=None,
+        close=False,
+        reduce_only=False,
+        post_only=False,
+        oco=False,
+        aff_code=None,
+        time_in_force=None,
+        leverage=None,
+        gid=None
+    )
+
+    res = asyncio.run(submit_order)
+    print("\Create order:")
+    print(res.notify_info[0])
+
+
+def test_submit_cancel_order():
+    order_id = 77921347342
+    
+    cancel_order = bfx.submit_cancel_order(order_id)
+
+    res = asyncio.run(cancel_order)
+    print("\Cancel order:")
+    print(res)
+
+
+def test_update_order():
+    # order_id = 77921374472    # Active order
+    order_id = 77921347342    # Already cancelled order
+    
+    update_order = bfx.submit_update_order(order_id)
+
+    res = asyncio.run(update_order)
+    print("\nUpdate order:")
+    print(res)
+
+
+def test_get_active_orders():
+    get_active_orders = bfx.get_active_orders('tTESTBTC:TESTUSD')
+
+    res = asyncio.run(get_active_orders)
+    print("\nActive orders:")
+    print(res)
+
+
+def test_get_all_active_orders():
+    get_all_active_orders = bfx.get_active_orders()
+
+    res = asyncio.run(get_all_active_orders)
+    print("\nActive orders ({} orders):".format(len(res)))
+    print(res)
+
+
+def test_get_order_history():
+    start = 1000 * datetime(2021, 11, 5).timestamp()
+    end = 1000 * datetime(2021, 11, 5, 23).timestamp()
+    
+    order_history = bfx.get_order_history('tTESTBTC:TESTUSD', start, end, limit=1000)
+
+    res = asyncio.run(order_history)
+    print("\nOrder history:")
+    print("{} orders".format(len(res)))
+    print(res)
+    print("Order IDs:")
+    print([order.id for order in res])
+
+
+def test_get_order_history_ids():
+    # order_id = 77921374472    # Active order
+    # order_id = 77921347342    # Already cancelled order
+    order_ids = [77769182836, 77769177293, 77769082712, 77769073775]    # Saved from above run
+    start = 1000 * datetime(2021, 11, 5).timestamp()
+    end = 1000 * datetime(2021, 11, 5, 23).timestamp()
+    
+    order_history = bfx.get_order_history('tTESTBTC:TESTUSD', start, end, ids=order_ids)
+
+    res = asyncio.run(order_history)
+    print("\nOrder history:")
+    print(res)
+
+
+def test_get_all_order_history():
+    order_history = bfx.get_order_history()
+
+    res = asyncio.run(order_history)
+    print("\nOrder history ({} orders):".format(len(res)))
+    print(res)
+
+
+def test_get_all_order_history_ids():
+    order_ids = [77769182836, 77769177293, 77769082712, 77769073775]    # Saved from above run
+    order_history = bfx.get_all_order_history(ids=order_ids)
+
+    res = asyncio.run(order_history)
+    print("\nOrder history ({} orders):".format(len(res)))
+    print(res)
+
+
+def test_get_trades():
+    start = 1000 * datetime(2021, 11, 5).timestamp()
+    end = 1000 * datetime(2021, 11, 5, 23).timestamp()
+    trades = bfx.get_trades(symbol='tTESTBTC:TESTUSD', start=start, end=end, limit=1000)
+    res = asyncio.run(trades)
+    print("\Trades ({} trades):".format(len(res)))
+    print(res)
+
+
+def test_get_trades_all():
+    trades = bfx.get_trades(limit=1000)
+    res = asyncio.run(trades)
+    print("\Trades ({} trades):".format(len(res)))
+    print(res)
+
+
+def test_get_active_positions():
+    active_positions = bfx.get_active_position()
+    res = asyncio.run(active_positions)
+    print("\Active positions ({} positions):".format(len(res)))
+    print(res)
+    
+    
+if __name__ == "__main__":
+    logging.basicConfig(level='DEBUG')
+    
+    test_get_all_active_orders()
+    test_get_all_order_history()
+    # test_get_all_order_history_ids()
+    # test_get_trades()
+    # test_get_trades_all()
+    # test_get_active_positions()


### PR DESCRIPTION
Description:
Add more flexibility in retrieving orders, positions and trades:
- Retrieve orders without specifying symbol
- Add optional arguments with sensible default values
- Add tests

Breaking changes:
[ ]

New features:
[x ]

Fixes:
[ x]

### PR status:
- [ ] Version bumped
- [ ] Change-log updated
